### PR TITLE
Specify HTTP protocol for JS assets

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -3,8 +3,8 @@
   <head>
     <title>Chartkick.js</title>
     <meta charset="utf-8">
-    <script src="//www.google.com/jsapi"></script>
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+    <script src="http://www.google.com/jsapi"></script>
+    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
     <script src="../chartkick.js"></script>
 
     <style>


### PR DESCRIPTION
The example page is more likely to be opened as a file, and not served from a web server. If we don't specify protocol (to let it be either HTTP or HTTPS),

``` html
<script src="//www.google.com/jsapi"></script>
```

then it fails to load when loading from a file like this

```
file://path/to/index.html
```
