### PR TITLE
changing the way the onresize event is handled in IE8. This way is handled only...

### DIFF
--- a/chartkick.js
+++ b/chartkick.js
@@ -518,7 +518,12 @@
 
       var resize = function (callback) {
         if (window.attachEvent) {
-          window.attachEvent("onresize", callback);
+          var handleResize = function(){
+            $(window).one("resize", function() {
+              callback();
+              setTimeout("handleResize()",100);
+            });
+          }
         } else if (window.addEventListener) {
           window.addEventListener("resize", callback, true);
         }


### PR DESCRIPTION
... once, and prevents an infinite resizing loop.

I've been using your js library integrated with angular, and when tested my app in IE8 I experienced an infinite resize loop (the charts shrinks slowly but continuously).
I found these two posts:
http://cyanbyfuchsia.wordpress.com/2012/06/20/window-resize-and-internet-explorer-8/
http://stackoverflow.com/questions/1852751/window-resize-event-firing-in-internet-explorer

and decided to implement the solution that seemed more tidy.
This code did the trick for me.

Hope it helps.
