### PR TITLE
Load jsapi using https instead of http

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -6,8 +6,8 @@
     <script>
       // var Chartkick = {language: "de"};
     </script>
-    <script src="http://www.google.com/jsapi"></script>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+    <script src="https://www.google.com/jsapi"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
 
     <!-- <script src="http://cdnjs.cloudflare.com/ajax/libs/zepto/1.1.2/zepto.min.js"></script> -->
     <!-- <script src="http://code.highcharts.com/highcharts.js"></script> -->


### PR DESCRIPTION
to fix the error from chrome browser

```
[blocked] The page at 'https://ankane.github.io/chartkick.js/examples/' was loaded over HTTPS, but ran insecure content from 'http://www.google.com/jsapi': this content should also be loaded over HTTPS.
 ankane.github.io/:1
[blocked] The page at 'https://ankane.github.io/chartkick.js/examples/' was loaded over HTTPS, but ran insecure content from 'http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js': this content should also be loaded over HTTPS.
```
