### PR TITLE
Add series marker shortcut

### DIFF
--- a/chartkick.js
+++ b/chartkick.js
@@ -322,7 +322,7 @@
               data[j][0] = data[j][0].getTime();
             }
           }
-          series[i].marker = {symbol: "circle"};
+          series[i].marker = series[i].marker || {symbol: "circle"};
         }
         options.series = series;
         new Highcharts.Chart(options);


### PR DESCRIPTION
Allows a marker type to get passed in with the data series. If it isn't
present, the default of a circle is used.
