### PR TITLE
Configure LineChart: Max marker points

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,23 @@ To specify a language for Google Charts, add:
 
 **before** the javascript files.
 
+### Configuration
+
+To specify defaults, add:
+
+```html
+<script>
+  var Chartkick = {
+    "language": "de", // Google Charts language
+    lineChart: {
+      marker: { maxPoints: 10 } // Don't display markers if there are more than 10 data points
+    }
+  };
+</script>
+```
+
+**before** the javascript files.
+
 ### Adapter
 
 If both Google Charts and Highcharts are loaded, choose between them with:

--- a/examples/index.html
+++ b/examples/index.html
@@ -4,7 +4,12 @@
     <title>Chartkick.js</title>
     <meta charset="utf-8">
     <script>
-      // var Chartkick = {language: "de"};
+      // var Chartkick = {
+      //   language: "de",
+      //   lineChart: {
+      //     marker: { maxPoints: 3 }
+      //   }
+      // };
     </script>
     <script src="http://www.google.com/jsapi"></script>
     <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>


### PR DESCRIPTION
- _Google & Highcharts:_ Configure line charts to hide their markers, after a certain number of data points.
- _Highcharts:_ You can also configure what symbol a series should use.
