### PR TITLE
Update google chart to new library loader

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -4,9 +4,10 @@
     <title>Chartkick.js</title>
     <meta charset="utf-8">
     <script>
-      // var Chartkick = {language: "de"};
+      var Chartkick = {language: "de", packages: ['corechart', 'timeline']};
     </script>
-    <script src="http://www.google.com/jsapi"></script>
+    <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
+    <!-- <script src="http://www.google.com/jsapi"></script> -->
     <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
 
     <!-- <script src="http://cdnjs.cloudflare.com/ajax/libs/zepto/1.1.2/zepto.min.js"></script> -->


### PR DESCRIPTION
Google update its chart gallery with new chart types and material design style on Bar chart, Line chart and more.
changes:
- Add a `theme` option with `'material'` value to use google material theme
- Use additional chart by load the appropriate package in `Chartkick.packages` option
