### PR TITLE
Drop jQuery and Zepto dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.0.2 [unreleased]
 
 - Fixed legend colors on scatter chart for Chart.js
+- Dropped jQuery and Zepto dependencies
 
 ## 2.0.1
 

--- a/README.md
+++ b/README.md
@@ -82,8 +82,6 @@ Make your pages load super fast and stop worrying about timeouts.  Give each cha
 new Chartkick.LineChart("chart-1", "/stocks");
 ```
 
-**Note:** This feature requires [jQuery](http://jquery.com/) or [Zepto](http://zeptojs.com/) at the moment.
-
 ### Options
 
 Min and max values

--- a/chartkick.js
+++ b/chartkick.js
@@ -164,16 +164,35 @@
   }
 
   function getJSON(element, url, success) {
-    var $ = window.jQuery || window.Zepto || window.$;
-    $.ajax({
-      dataType: "json",
-      url: url,
-      success: success,
-      error: function (jqXHR, textStatus, errorThrown) {
-        var message = (typeof errorThrown === "string") ? errorThrown : errorThrown.message;
-        chartError(element, message);
-      }
-    });
+    ajaxCall(url, success, function(jqXHR, textStatus, errorThrown) {
+      var message = (typeof errorThrown === "string") ? errorThrown : errorThrown.message;
+      chartError(element, message);
+    })
+  }
+
+  function ajaxCall(url, success, error) {
+    var $ = window.jQuery || window.Zepto || window.$
+
+    if ($) {
+      $.ajax({
+        dataType: "json",
+        url: url,
+        success: success,
+        error: error
+      });
+    } else {
+      var xhr = new XMLHttpRequest();
+      xhr.open('GET', url, true);
+      xhr.setRequestHeader('Content-Type', 'application/json');
+      xhr.onload = function() {
+        if (xhr.status === 200) {
+          success(JSON.parse(xhr.responseText), xhr.statusText, xhr)
+        } else {
+          error(xhr, 'error', xhr.statusText)
+        }
+      };
+      xhr.send()
+    }
   }
 
   function errorCatcher(chart, callback) {


### PR DESCRIPTION
This was handy for testing without Apache/nginx/etc: https://chrome.google.com/webstore/detail/web-server-for-chrome/ofhbbkphhbklhfoeikjpcbhemlocgigb