### PR TITLE
Previously 0-values were not plotted into chart, now they do.

### DIFF
--- a/chartkick.js
+++ b/chartkick.js
@@ -988,7 +988,9 @@
             labels.push(value);
             for (j = 0; j < series.length; j++) {
               // Chart.js doesn't like undefined
-              rows2[j].push(rows[i][j] || null);
+              // -- Fix: Before 0 values were considered undefined and setting
+              // the value to null. So 0 values were not plotted in the chart.
+              rows2[j].push((rows[i][j] === "undefined") ? null : rows[i][j]);
             }
           }
 


### PR DESCRIPTION
For ChartJS, data with 0 values were not being plotted into the chart, so there were gaps in places where it shouldn't. That leads to confusion, as the 0 values were confused with null values (a.k.a no data). An use case is for example a chart that measures the heartbeats of an application, 0 values NEED to be plotted as that data exists and is valuable.