### PR TITLE
fix #32 , use https url for api

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -6,13 +6,13 @@
     <script>
       // var Chartkick = {language: "de"};
     </script>
-    <script src="http://www.google.com/jsapi"></script>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+    <script src="https://www.google.com/jsapi"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
 
-    <!-- <script src="http://cdnjs.cloudflare.com/ajax/libs/zepto/1.1.2/zepto.min.js"></script> -->
-    <!-- <script src="http://code.highcharts.com/highcharts.js"></script> -->
-    <!-- <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script> -->
-    <!-- <script src="http://code.highcharts.com/2.1.9/highcharts.js"></script> -->
+    <!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/zepto/1.1.2/zepto.min.js"></script> -->
+    <!-- <script src="https://code.highcharts.com/highcharts.js"></script> -->
+    <!-- <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script> -->
+    <!-- <script src="https://code.highcharts.com/2.1.9/highcharts.js"></script> -->
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.1.4/Chart.bundle.js"></script>
 


### PR DESCRIPTION
fix the error `Mixed Content: The page at 'https://ankane.github.io/chartkick.js/examples/' was loaded over HTTPS, but requested an insecure script 'http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js'. This request has been blocked; the content must be served over HTTPS.
2016-12-05 10:51:42.303 chartkick.js:1124 Uncaught Error: No adapter foundrenderChart @ chartkick.js:1124processScatterData @ chartkick.js:1268errorCatcher @ chartkick.js:181fetchDataSource @ chartkick.js:196setElement @ chartkick.js:1296ScatterChart @ chartkick.js:1321(anonymous function) @ (index):67`