### PR TITLE
Support for named stacks w/ Highcharts & Chart.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.2.3 [unreleased]
 
+- Added named `stack` option to datasets for Chart.js & Highcharts
 - Added `xtype` option
 - Added `points` option
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,18 @@ data = [
 new Chartkick.LineChart("chart-1", data)
 ```
 
+Multiple series with custom stacks - *Chart.js 2.5+ or HighCharts*
+
+```javascript
+data = [
+  {name: "John", data: {"Tuesday": 3, "Friday": 4}, stack: 'men'},
+  {name: "Frank", data: {"Tuesday": 1, "Friday": 8}, stack: 'men'},
+  {name: "Sarah", data: {"Tuesday": 3, "Friday": 4}, stack: 'women'},
+  {name: "Jane", data: {"Tuesday": 1, "Friday": 8}, stack: 'women'}
+]
+new Chartkick.BarChart("chart-1", data, {stacked: true})
+```
+
 ### Say Goodbye To Timeouts
 
 Make your pages load super fast and stop worrying about timeouts. Give each chart its own endpoint.

--- a/chartkick.js
+++ b/chartkick.js
@@ -578,7 +578,8 @@
 
             newSeries.push({
               name: series[i].name,
-              data: d
+              data: d,
+              stack: series[i].stack ? series[i].stack : null
             });
           }
           options.series = newSeries;
@@ -1227,6 +1228,7 @@
             var dataset = {
               label: s.name,
               data: rows2[i],
+              stack: s.stack ? s.stack : null,
               fill: chartType === "area",
               borderColor: color,
               backgroundColor: backgroundColor,

--- a/examples/index.html
+++ b/examples/index.html
@@ -136,6 +136,12 @@
       new Chartkick.BarChart("multiple-bar-stacked", [{name: "Series A", data: [["0",32],["1",46],["2",28],["3",21],["4",20],["5",13],["6",27]]}, {name: "Series B", data: [["0",32],["1",46],["2",28],["3",21],["4",20],["5",13],["6",27]]}], {max: 80, stacked: true});
     </script>
 
+    <h1>Multiple Series Bar Stacked &amp; Grouped (Chart.js 2.5+ or HighCharts only)</h1>
+    <div id="multiple-bar-stacked-grouped" style="height: 300px;"></div>
+    <script>
+      new Chartkick.BarChart("multiple-bar-stacked-grouped", [{name: "Series A", data: [["0",32],["1",46],["2",28],["3",21],["4",20],["5",13],["6",27]], stack: 'stack 1'}, {name: "Series B", data: [["0",32],["1",46],["2",28],["3",21],["4",20],["5",13],["6",27]], stack: 'stack 2'}, {name: "Series C", data: [["0",12],["1",16],["2",18],["3",11],["4",10],["5",3],["6",17]], stack: 'stack 2'}], {max: 80, stacked: true});
+    </script>
+
     <h1>Multiple Series Column Stacked</h1>
     <div id="multiple-column-stack" style="height: 300px;"></div>
     <script>


### PR DESCRIPTION
Highcharts [currently supports](http://www.highcharts.com/demo/column-stacked-and-grouped) grouped & stacked bar/column charts, and Chart.js is [adding support in 2.5](https://github.com/chartjs/Chart.js/pull/3563). This adds support for passing this extra data property through to these libraries. I've tested, and including this property in current Chart.js (2.4) doesn't break anything - it just renders like a normal stacked chart.