### PR TITLE
Update jsnext:main to point to ES5 code

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "homepage": "https://github.com/ankane/chartkick.js",
   "description": "Create beautiful charts with one line of JavaScript",
   "main": "dist/chartkick.js",
-  "module": "src/chartkick.js",
-  "jsnext:main": "src/chartkick.js",
+  "module": "dist/chartkick.js",
+  "jsnext:main": "dist/chartkick.js",
   "scripts": {
     "build": "webpack",
     "lint": "eslint src"


### PR DESCRIPTION
When building react project that uses chartkick and react-chartkick packages there is the 'Failed to compile error' pointing to one of the files from chartkick package.

![image](https://user-images.githubusercontent.com/17239925/37857313-fa97e0d2-2ef1-11e8-9574-0b5570cd28ac.png)

According to create-react-app guidelines the package should be published with pre-compiled code.
https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#npm-run-build-fails-to-minify

Furthermore, it seems that jsnext:main (module) should point to ES5 compiled code with exception of import, export syntax, however code in src folder is ES5+.
https://shuheikagawa.com/blog/2017/01/05/main-jsnext-main-and-module/
