### PR TITLE
Closes #104 Fix Tooltip point color for Highcharts adapter

### DIFF
--- a/src/adapters/highcharts.js
+++ b/src/adapters/highcharts.js
@@ -103,7 +103,7 @@ let setFormatOptions = function(chart, options, chartType) {
 
   if (!options.tooltip.pointFormatter) {
     options.tooltip.pointFormatter = function () {
-      return '<span style="color:' + this.color + '>\u25CF</span> ' + formatValue(this.series.name + ': <b>', this.y, formatOptions) + '</b><br/>';
+      return '<span style="color:' + this.color + '">\u25CF</span> ' + formatValue(this.series.name + ': <b>', this.y, formatOptions) + '</b><br/>';
     };
   }
 };


### PR DESCRIPTION
This pr fixes a small typo that made tooltip points always black when using the Highcharts adapter.