### PR TITLE
Support callback as data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,15 @@ Times can be a `Date` or a string (strings are parsed)
 new Chartkick.LineChart("chart-1", [[new Date(), 5], ["2017-01-01 00:00:00 UTC", 7]])
 ```
 
+Data can also be a callback
+
+```javascript
+function fetchChart(success, fail) {
+  fetch(url).then(success).catch(fail)
+}
+new Chartkick.LineChart("chart-1", fetchChart)
+```
+
 ### Multiple Series
 
 You can pass a few options with a series:

--- a/src/index.js
+++ b/src/index.js
@@ -41,10 +41,10 @@ function fetchDataSource(chart, dataSource) {
       chartError(chart.element, message);
     });
   } else if (typeof dataSource === "function") {
-    Promise.resolve(dataSource()).then(function (data) {
+    dataSource(function (data) {
       chart.rawData = data;
       errorCatcher(chart);
-    }).catch(function (message) {
+    }, function (message) {
       chartError(chart.element, message);
     });
   } else {

--- a/src/index.js
+++ b/src/index.js
@@ -40,6 +40,13 @@ function fetchDataSource(chart, dataSource) {
     }, function (message) {
       chartError(chart.element, message);
     });
+  } else if (typeof dataSource === "function") {
+    Promise.resolve(dataSource()).then(function (data) {
+      chart.rawData = data;
+      errorCatcher(chart);
+    }).catch(function (message) {
+      chartError(chart.element, message);
+    });
   } else {
     chart.rawData = dataSource;
     errorCatcher(chart);
@@ -386,14 +393,16 @@ class Chart {
       let sep = this.dataSource.indexOf("?") === -1 ? "?" : "&";
       let url = this.dataSource + sep + "_=" + (new Date()).getTime();
       fetchDataSource(this, url);
+    } else if (typeof this.dataSource === "function") {
+      fetchDataSource(this, this.dataSource);
     }
   }
 
   startRefresh() {
     let refresh = this.options.refresh;
 
-    if (refresh && typeof this.dataSource !== "string") {
-      throw new Error("Data source must be a URL for refresh");
+    if (refresh && typeof this.dataSource !== "string" && typeof this.dataSource !== "function") {
+      throw new Error("Data source must be a URL or callback for refresh");
     }
 
     if (!this.intervalId) {


### PR DESCRIPTION
I initially need to add an `Authorization` header contains a bearer token. Since my project is already using a configured `axios`, supporting callback as data source would solve my problem and provide most flexibility meanwhile.