### PR TITLE
Add support for x-axis dates on scatter

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -616,6 +616,12 @@
       new Chartkick.ScatterChart("scatter-same-x", [[0, -5], [-10, -10], [5, 10], [-5, 5], [10, -5], [-10, 10], [-5, 10]]);
     </script>
 
+    <h1>Scatter Same X Dates</h1>
+    <div id="scatter-dates" style="height: 300px;"></div>
+    <script>
+      new Chartkick.ScatterChart("scatter-dates", [["2013-02-10", 0.11], ["2013-02-11", 0.2], ["2013-02-11", 0.6], ["2013-02-12", 0.3], ["2013-02-13",0.2], ["2013-02-14",0.5], ["2013-02-15",0.3], ["2013-02-16",0.8], ["2013-02-16",0.2], ["2013-02-16",0.4], ["2013-02-17",0.6], ["2013-02-18",0.6], ["2013-02-18",0.35], ["2013-02-19",0.12], ["2013-02-20",0.5], ["2013-02-21",0.3]]);
+    </script>
+
     <h1>Numeric Axis Line</h1>
     <div id="numeric-axis-line" style="height: 300px;"></div>
     <script>

--- a/src/adapters/chartjs.js
+++ b/src/adapters/chartjs.js
@@ -608,7 +608,14 @@ export default class {
 
     let data = createDataTable(chart, options, chartType, this.library);
 
-    options.scales.xAxes[0].type = "linear";
+    if (data.labels[0] instanceof Date) {
+      options.scales.xAxes[0].type = "time";
+      options.scales.xAxes[0].time.unit = "day";
+      options.scales.xAxes[0].time.tooltipFormat = "MMM D YYYY";
+    } else {
+      options.scales.xAxes[0].type = "linear";
+    }
+
     options.scales.xAxes[0].position = "bottom";
 
     this.drawChart(chart, chartType, data, options);

--- a/src/adapters/google.js
+++ b/src/adapters/google.js
@@ -229,7 +229,7 @@ export default class {
       let chartOptions = {};
       let options = jsOptions(chart, chart.options, chartOptions);
 
-      let series = chart.data, rows2 = [], i, j, data, d;
+      let series = chart.data, rows2 = [], i, j, data, d, dataType, dateFormatter;
       for (i = 0; i < series.length; i++) {
         series[i].name = series[i].name || "Value";
         d = series[i].data;
@@ -242,11 +242,24 @@ export default class {
       }
 
       data = new this.library.visualization.DataTable();
-      data.addColumn("number", "");
+
+      if (series[0].data[0][0] instanceof Date) {
+        dataType = "datetime";
+      } else {
+        dataType = "number";
+      }
+
+      data.addColumn(dataType, "");
       for (i = 0; i < series.length; i++) {
         data.addColumn("number", series[i].name);
       }
       data.addRows(rows2);
+
+      if (dataType === "datetime") {
+        // https://developers.google.com/chart/interactive/docs/reference#dateformatter
+        dateFormatter = new google.visualization.DateFormat({pattern: "MMM d YYYY"});
+        dateFormatter.format(data, 0);
+      }
 
       this.drawChart(chart, "ScatterChart", data, options);
     });

--- a/src/adapters/highcharts.js
+++ b/src/adapters/highcharts.js
@@ -176,8 +176,31 @@ export default class {
   }
 
   renderScatterChart(chart) {
-    let options = jsOptions(chart, chart.options, {});
+    let options = jsOptions(chart, chart.options, {}), data, i, j;
     options.chart.type = "scatter";
+
+    let series = chart.data;
+    for (i = 0; i < series.length; i++) {
+      series[i].name = series[i].name || "Value";
+      data = series[i].data;
+      if (chart.xtype === "datetime") {
+        for (j = 0; j < data.length; j++) {
+          data[j][0] = data[j][0].getTime();
+        }
+      }
+      series[i].marker = {symbol: "circle"};
+      if (chart.options.points === false) {
+        series[i].marker.enabled = false;
+      }
+    }
+
+    if (chart.xtype === "datetime") {
+      options.xAxis.type = "datetime";
+      options.tooltip.formatter = function() {
+        return `(<b>${Highcharts.dateFormat('%b %d %Y', new Date(this.x))}</b>, <b>${this.y}</b>)`;
+      }
+    }
+
     this.drawChart(chart, chart.data, options);
   }
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -106,10 +106,10 @@ function toDate(n) {
     } else {
       n = toStr(n);
       if ((matches = n.match(DATE_PATTERN))) {
-      year = parseInt(matches[1], 10);
-      month = parseInt(matches[3], 10) - 1;
-      day = parseInt(matches[5], 10);
-      return new Date(year, month, day);
+        year = parseInt(matches[1], 10);
+        month = parseInt(matches[3], 10) - 1;
+        day = parseInt(matches[5], 10);
+        return new Date(year, month, day);
       } else { // str
         // try our best to get the str into iso8601
         // TODO be smarter about this


### PR DESCRIPTION
By taking advantage of `detectXType()` we can detect numbers or dates for a scatter chart. Then to support multiple points on the same day we can add some seconds to points on the same day. Maintains passivity for number scatter charts.

### Notes
- Adding seconds to a date is harder than it sounds; read more [here](https://stackoverflow.com/a/1214753)
- To hide the time on points I overrode the tooltip formats
- Multiple points on the same day will work with data that's an array of arrays; if the data is key-value pairs, the behavior seems to vary by charting library
- Dates in Highchart are offset by local time which is consistent with date charts