### PR TITLE
Fix line/scatter chart x axis options being overridden

### DIFF
--- a/src/adapters/chartjs.js
+++ b/src/adapters/chartjs.js
@@ -560,8 +560,8 @@ export default class {
     let data = createDataTable(chart, options, chartType || "line");
 
     if (chart.xtype === "number") {
-      options.scales.x.type = "linear";
-      options.scales.x.position = "bottom";
+      options.scales.x.type = options.scales.x.type || "linear";
+      options.scales.x.position = options.scales.x.position ||"bottom";
     } else {
       options.scales.x.type = chart.xtype === "string" ? "category" : "time";
     }
@@ -651,8 +651,8 @@ export default class {
 
     let data = createDataTable(chart, options, chartType);
 
-    options.scales.x.type = "linear";
-    options.scales.x.position = "bottom";
+    options.scales.x.type = options.scales.x.type || "linear";
+    options.scales.x.position = options.scales.x.position || "bottom";
 
     // prevent grouping hover and tooltips
     if (!("mode" in options.interaction)) {

--- a/src/adapters/highcharts.js
+++ b/src/adapters/highcharts.js
@@ -154,7 +154,11 @@ export default class {
     }
 
     let options = jsOptions(chart, chart.options, chartOptions), data, i, j;
-    options.xAxis.type = chart.xtype === "string" ? "category" : (chart.xtype === "number" ? "linear" : "datetime");
+    if (chart.xtype === "number") {
+      options.xAxis.type = options.xAxis.type || "linear";
+    } else {
+      options.xAxis.type = chart.xtype === "string" ? "category" : "datetime";
+    }
     if (!options.chart.type) {
       options.chart.type = chartType;
     }


### PR DESCRIPTION
### Issue
This PR resolves an issue where some of the parameters passed to the charting libraries are overridden. This prevents the use of logarithmic axes or the repositioning of the axis. Theorectically this would also allow a separately defined custom axis to used, but this is untested.

### Example
Consider
```ruby
= line_chart({1 => 0, 10 => -1, 100 => -2, 1000 => -3}, library: { scales: {x: {type: "logarithmic", position: "top"}}})
```
The current behaviour:
![image (1)](https://user-images.githubusercontent.com/42130157/124690931-513e9180-df1e-11eb-9de6-d96bfc1a2b4d.png)

Modified behaviour:
![image (2)](https://user-images.githubusercontent.com/42130157/124690970-62879e00-df1e-11eb-89d4-8ea714d8b0fa.png)
