### PR TITLE
feat(chartjs): add yAxisID option to series

### DIFF
--- a/src/adapters/chartjs.js
+++ b/src/adapters/chartjs.js
@@ -432,7 +432,8 @@ function createDataTable(chart, options, chartType) {
       fill: chartType === "area",
       borderColor: color,
       backgroundColor: backgroundColor,
-      borderWidth: 2
+      borderWidth: 2,
+      yAxisID: s.yAxisID || "y"
     };
 
     const pointChart = chartType === "line" || chartType === "area" || chartType === "scatter" || chartType === "bubble";


### PR DESCRIPTION
Add a right y-axis to a line chart on Chart.js

```javascript
new Chartkick.LineChart("multiple-line-right-y-axis", [
  {yAxisID: "y", "name":"Score","data":{"2021-02-10":4.1,"2021-02-17":4.3,"2021-02-24":4,"2021-03-03":4.1,"2021-03-10":4.2,"2021-03-17":4.3,"2021-03-24":4.8,"2021-03-31":4.7}},
  {yAxisID: "yr", "name":"Reviews","data":{"2021-02-10":10,"2021-02-17":20,"2021-02-24":30,"2021-03-03":15,"2021-03-10":30,"2021-03-17":9,"2021-03-24":4,"2021-03-31":47}},
], {
  library: {
    responsive: true,
    interaction: {
      mode: "index",
      intersect: false,
    },
    scales: {
      y: {
        max: 5,
        min: 0,
        position: "left",
        ticks: {
          stepsize: 1
        }
      },
      yr: {
        suggestedMax: 50,
        suggestedMin: 0,
        position: "right",
        ticks: {
          stepSize: 20
        },
        grid: {
          drawOnChartArea: false
        }
      }
    }
  }
});

```

![image](https://github.com/user-attachments/assets/8c623fc4-e90e-47af-b957-ffb776450d14)

